### PR TITLE
Added pkgConfig information for C ZMQ library import

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "CZeroMQ"
+    name: "CZeroMQ",
+    pkgConfig: "libzmq"
 )


### PR DESCRIPTION
I'm not sure if this is something that you want upstream, but it's worth a shot.

This just adds a pkgconfig label for libzmq that SwiftPM can use to find the include and link paths.
